### PR TITLE
rag: add project schema + allowlist ingestion (v1)

### DIFF
--- a/rag/README.md
+++ b/rag/README.md
@@ -8,3 +8,44 @@ Endpoints:
 GET /health
 POST /ingest
 POST /query
+
+## Project Knowledge (V1)
+
+This service supports a free-first RAG approach:
+
+- Curated project allowlist
+- Public, read-only data
+- Fail-open design (no response never blocks AI)
+
+Planned roadmap:
+1. Free sources (allowlist, public metadata)
+2. Paid APIs (optional adapters)
+3. Custom indexer
+
+## How to test in 60 seconds
+
+Assuming the service is running on port 8001:
+
+```bash
+curl http://localhost:8001/health
+```
+
+```bash
+curl http://localhost:8001/projects
+```
+
+```bash
+curl -X POST http://localhost:8001/ingest/projects \
+  -H "Content-Type: application/json" \
+  -d @rag/data/projects_allowlist.json
+```
+
+```bash
+curl -s $RAG_URL/projects/ton
+```
+
+```bash
+curl -X POST http://localhost:8001/query \
+  -H "Content-Type: application/json" \
+  -d "{\"query\":\"ton\", \"top_k\": 3}"
+```

--- a/rag/data/projects_allowlist.json
+++ b/rag/data/projects_allowlist.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "ton",
+    "name": "TON",
+    "slug": "ton",
+    "description": "The Open Network blockchain ecosystem.",
+    "tags": ["blockchain", "ecosystem"],
+    "official_links": {
+      "website": "https://ton.org",
+      "docs": "https://docs.ton.org"
+    },
+    "sources": [
+      {
+        "source_name": "allowlist",
+        "source_url": "rag/data/projects_allowlist.json",
+        "fetched_at": "2026-02-04"
+      }
+    ],
+    "updated_at": "2026-02-04"
+  }
+]


### PR DESCRIPTION
This PR introduces a minimal RAG V1 “project knowledge” foundation.

What’s included:
- Project schema (normalized, source-agnostic)
- Read-only project endpoints
- Allowlist ingestion (free-first)
- Fully fail-open (no changes to existing flow)

What’s NOT included:
- embeddings/vector DB
- paid APIs
- indexer
- UI changes

Safe to deploy: if RAG is unavailable, the bot continues as before.
