### PR TITLE
feat(front-wallet): add non-blocking mnemonic wallet service with telegram secure storage

### DIFF
--- a/front/lib/wallet/wallet_service.dart
+++ b/front/lib/wallet/wallet_service.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:bip39/bip39.dart' as bip39;
+import 'package:cryptography/cryptography.dart';
+
+import 'wallet_storage.dart';
+import 'wallet_types.dart';
+
+class WalletServiceImpl implements WalletService {
+  static final Ed25519 _ed25519 = Ed25519();
+
+  final WalletStorage _storage;
+
+  WalletServiceImpl({WalletStorage? storage})
+      : _storage = storage ?? WalletStorage();
+
+  @override
+  Future<WalletMaterial> getOrCreate() async {
+    final existing = await getExisting();
+    if (existing != null) return existing;
+
+    final mnemonic = bip39.generateMnemonic(strength: 256);
+    await _storage.writeMnemonic(mnemonic);
+    return _materialFromMnemonic(mnemonic);
+  }
+
+  @override
+  Future<WalletMaterial?> getExisting() async {
+    final mnemonic = await _storage.readMnemonic();
+    if (mnemonic == null || mnemonic.trim().isEmpty) return null;
+    return _materialFromMnemonic(mnemonic);
+  }
+
+  @override
+  Future<void> clear() {
+    return _storage.clearMnemonic();
+  }
+
+  Future<WalletMaterial> _materialFromMnemonic(String mnemonic) async {
+    final normalized = mnemonic.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+    final words = normalized.split(' ').where((w) => w.isNotEmpty).toList();
+    if (words.isEmpty) {
+      throw StateError('Mnemonic is empty');
+    }
+
+    final seedBytes = bip39.mnemonicToSeed(normalized);
+    final seed32 = Uint8List.fromList(seedBytes.sublist(0, 32));
+    final keyPair = await _ed25519.newKeyPairFromSeed(seed32);
+    final keyData = await keyPair.extract();
+
+    return WalletMaterial(
+      mnemonicWords: words,
+      publicKeyHex: _toHex(keyData.publicKey.bytes),
+    );
+  }
+
+  String _toHex(List<int> bytes) {
+    final buffer = StringBuffer();
+    for (final b in bytes) {
+      buffer.write(b.toRadixString(16).padLeft(2, '0'));
+    }
+    return buffer.toString();
+  }
+}

--- a/front/lib/wallet/wallet_types.dart
+++ b/front/lib/wallet/wallet_types.dart
@@ -1,0 +1,17 @@
+class WalletMaterial {
+  final List<String> mnemonicWords;
+  final String publicKeyHex;
+
+  const WalletMaterial({
+    required this.mnemonicWords,
+    required this.publicKeyHex,
+  });
+
+  String get mnemonic => mnemonicWords.join(' ');
+}
+
+abstract class WalletService {
+  Future<WalletMaterial> getOrCreate();
+  Future<WalletMaterial?> getExisting();
+  Future<void> clear();
+}

--- a/front/pubspec.yaml
+++ b/front/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  bip39: ^1.0.6
   cryptography: ^2.7.0
   flutter_svg: ^2.2.2
   http: ^1.1.0
@@ -56,4 +57,3 @@ flutter:
       fonts:
         - asset: assets/fonts/AEROPORT-MONOSPACED-TRIAL.OTF
           weight: 400
-


### PR DESCRIPTION
That contains the full V1 wallet plumbing (no layout changes).

Description:
This PR introduces a minimal front-wallet layer that deterministically derives an Ed25519 keypair from a BIP-39 mnemonic and stores it securely in the Telegram WebApp context with a browser fallback.
​
Key changes:
​
Add WalletService/WalletMaterial abstractions and WalletServiceImpl using bip39 and cryptography to generate and derive an Ed25519 keypair from a 24-word mnemonic.
​
Implement WalletStorage that prefers Telegram WebApp SecureStorage/secureStorage and falls back to window.localStorage, with async JS interop and timeouts.
​
Wire non-blocking wallet warm-up into BootstrapScreen so key material is prepared early without blocking app startup or sign-in, with safe error handling and logging.
​
Add bip39 and cryptography dependencies to front/pubspec.yaml for mnemonic generation and Ed25519 operations.
​
Notes:
​
Wallet warm-up is fire-and-forget and never blocks bootstrap flow (including standalone mode).
​
Existing users keep their mnemonic if already present; new users get a fresh 256-bit-strength mnemonic on first access.
​