### PR TITLE
fix(nsis): wait for app exit before CopyFiles; shadow extractAppPackage

### DIFF
--- a/app/windows/extractAppPackage.nsh
+++ b/app/windows/extractAppPackage.nsh
@@ -1,0 +1,146 @@
+; Shadow of app-builder-lib templates/nsis/include/extractAppPackage.nsh
+; (buildResources is searched before the bundled template — see NSIS !addincludedir order.)
+;
+; Change: before each CopyFiles attempt (and on each retry), Call HspKillBeforeCopy so taskkill
+; runs when stock _CHECK_APP_RUNNING is too early or RetryExtract7za only slept.
+; Sync with upstream when upgrading electron-builder / app-builder-lib.
+
+!macro extractEmbeddedAppPackage
+  !ifdef COMPRESS
+    SetCompress off
+  !endif
+
+  Var /GLOBAL packageArch
+  
+  !insertmacro identify_package
+  !insertmacro compute_files_for_current_arch
+
+  !ifdef COMPRESS
+    SetCompress "${COMPRESS}"
+  !endif
+
+  !insertmacro decompress
+  !insertmacro custom_files_post_decompression
+!macroend
+
+!macro identify_package 
+  !ifdef APP_32
+    StrCpy $packageArch "32"
+  !endif
+  !ifdef APP_64
+    ${if} ${RunningX64}
+    ${OrIf} ${IsNativeARM64}
+      StrCpy $packageArch "64"
+    ${endif}
+  !endif
+  !ifdef APP_ARM64
+    ${if} ${IsNativeARM64}
+      StrCpy $packageArch "ARM64"
+    ${endif}
+  !endif
+!macroend
+
+!macro compute_files_for_current_arch
+  ${if} $packageArch == "ARM64"
+    !ifdef APP_ARM64
+      !insertmacro arm64_app_files
+    !endif
+  ${elseif} $packageArch == "64"
+    !ifdef APP_64
+      !insertmacro x64_app_files
+    !endif
+  ${else}
+    !ifdef APP_32
+      !insertmacro ia32_app_files
+    !endif
+  ${endIf}
+!macroend
+
+!macro custom_files_post_decompression
+  ${if} $packageArch == "ARM64"
+    !ifmacrodef customFiles_arm64
+      !insertmacro customFiles_arm64
+    !endif
+  ${elseif} $packageArch == "64"
+    !ifmacrodef customFiles_x64
+      !insertmacro customFiles_x64
+    !endif
+  ${else}
+    !ifmacrodef customFiles_ia32
+      !insertmacro customFiles_ia32
+    !endif
+  ${endIf}
+!macroend
+
+!macro arm64_app_files
+  File /oname=$PLUGINSDIR\app-arm64.${COMPRESSION_METHOD} "${APP_ARM64}"
+!macroend
+
+!macro x64_app_files
+  File /oname=$PLUGINSDIR\app-64.${COMPRESSION_METHOD} "${APP_64}"
+!macroend
+
+!macro ia32_app_files
+  File /oname=$PLUGINSDIR\app-32.${COMPRESSION_METHOD} "${APP_32}"
+!macroend
+
+!macro decompress
+  !ifdef ZIP_COMPRESSION
+    nsisunz::Unzip "$PLUGINSDIR\app-$packageArch.zip" "$INSTDIR"
+    Pop $R0
+    StrCmp $R0 "success" +3
+      MessageBox MB_OK|MB_ICONEXCLAMATION "$(decompressionFailed)$\n$R0"
+      Quit
+  !else
+    !insertmacro extractUsing7za "$PLUGINSDIR\app-$packageArch.7z"
+  !endif
+!macroend
+
+!macro extractUsing7za FILE
+  Push $OUTDIR
+  CreateDirectory "$PLUGINSDIR\7z-out"
+  ClearErrors
+  SetOutPath "$PLUGINSDIR\7z-out"
+  Nsis7z::Extract "${FILE}"
+  Pop $R0
+  SetOutPath $R0
+
+  # Retry counter
+  StrCpy $R1 0
+
+  LoopExtract7za:
+    IntOp $R1 $R1 + 1
+    Call HspKillBeforeCopy
+
+    # Attempt to copy files in atomic way
+    CopyFiles /SILENT "$PLUGINSDIR\7z-out\*" $OUTDIR
+    IfErrors 0 DoneExtract7za
+
+    DetailPrint `Can't modify "${PRODUCT_NAME}"'s files.`
+    ${if} $R1 < 5
+      # Try copying a few times before asking for a user action.
+      Goto RetryExtract7za
+    ${else}
+      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDRETRY IDCANCEL AbortExtract7za
+    ${endIf}
+
+    # As an absolutely last resort after a few automatic attempts and user
+    # intervention - we will just overwrite everything with `Nsis7z::Extract`
+    # even though it is not atomic and will ignore errors.
+
+    # Clear the temporary folder first to make sure we don't use twice as
+    # much disk space.
+    RMDir /r "$PLUGINSDIR\7z-out"
+
+    Nsis7z::Extract "${FILE}"
+    Goto DoneExtract7za
+
+  AbortExtract7za:
+    Quit
+
+  RetryExtract7za:
+    ; No fixed delay: next LoopExtract7za runs HspKillBeforeCopy + wait-until-gone before CopyFiles.
+    Goto LoopExtract7za
+
+  DoneExtract7za:
+!macroend

--- a/app/windows/installer-hooks.nsi
+++ b/app/windows/installer-hooks.nsi
@@ -60,7 +60,6 @@ Function .onInstSuccess
   ; Use one-shot guard so Finish-page fallback does not launch twice.
   StrCmp $HspDidLaunchApp "1" hspInstSuccessAfterLaunch
   StrCpy $HspDidLaunchApp "1"
-  Sleep 500
   Call HspLaunchInstalledApp
 hspInstSuccessAfterLaunch:
   !insertmacro HspAppendInstallerLog "INSTALL_SUCCESS"
@@ -90,6 +89,33 @@ FunctionEnd
 Function HspInstFilesShow
   SetDetailsView show
   SetDetailsPrint both
+FunctionEnd
+
+; Poll until ${APP_EXECUTABLE_FILENAME} is not listed by WMI (handles spaced names; no fixed delay on success).
+; $R8 = iteration cap (~300 * 50ms max); uses $0 from ExecWait.
+Function HspWaitUntilExeNotRunning
+  StrCpy $R8 0
+hspWaitExePoll:
+  ; Exit 0 = process still present; exit 1 = no matching process (or findstr found no line).
+  ExecWait `"$WINDIR\System32\cmd.exe" /C "wmic process where \"name='${APP_EXECUTABLE_FILENAME}'\" get ProcessId /value 2>nul | findstr /B ProcessId= >nul && exit /b 0 || exit /b 1"`
+  IntCmp $0 0 hspWaitExeStill
+  Return
+hspWaitExeStill:
+  IntOp $R8 $R8 + 1
+  IntCmp $R8 300 0 0 hspWaitExeGiveUp
+  Sleep 50
+  Goto hspWaitExePoll
+hspWaitExeGiveUp:
+FunctionEnd
+
+; Called before each CopyFiles from 7z-out to $INSTDIR (see windows/extractAppPackage.nsh retry loop).
+Function HspKillBeforeCopy
+  SetDetailsView show
+  SetDetailsPrint both
+  DetailPrint "[installer] unlock copy target (attempt $R1): taskkill /T ${APP_EXECUTABLE_FILENAME}"
+  nsExec::Exec `%SYSTEMROOT%\System32\cmd.exe /c taskkill /F /T /IM "${APP_EXECUTABLE_FILENAME}" /FI "USERNAME eq %USERNAME%"`
+  Pop $R9
+  Call HspWaitUntilExeNotRunning
 FunctionEnd
 
 Function HspFinishPageShow
@@ -169,12 +195,12 @@ FunctionEnd
   !insertmacro HspInstallDetailPrint "[installer] stop running processes (electron-builder + extra taskkill)"
   !insertmacro _CHECK_APP_RUNNING
   !insertmacro HspInstallDetailPrint "[installer] extra taskkill pass (spaced product name / stubborn locks)"
-  nsExec::Exec `%SYSTEMROOT%\System32\cmd.exe /c taskkill /F /IM "${APP_EXECUTABLE_FILENAME}" /FI "USERNAME eq %USERNAME%"`
+  nsExec::Exec `%SYSTEMROOT%\System32\cmd.exe /c taskkill /F /T /IM "${APP_EXECUTABLE_FILENAME}" /FI "USERNAME eq %USERNAME%"`
   Pop $R9
-  Sleep 2000
-  nsExec::Exec `%SYSTEMROOT%\System32\cmd.exe /c taskkill /F /IM "${APP_EXECUTABLE_FILENAME}" /FI "USERNAME eq %USERNAME%"`
+  Call HspWaitUntilExeNotRunning
+  nsExec::Exec `%SYSTEMROOT%\System32\cmd.exe /c taskkill /F /T /IM "${APP_EXECUTABLE_FILENAME}" /FI "USERNAME eq %USERNAME%"`
   Pop $R9
-  Sleep 2000
+  Call HspWaitUntilExeNotRunning
 !macroend
 !endif
 


### PR DESCRIPTION
- Add windows/extractAppPackage.nsh: call HspKillBeforeCopy before each 7z CopyFiles attempt (and retries) so taskkill runs after uninstallOldVersion, not only at CHECK_APP_RUNNING.
- Add HspWaitUntilExeNotRunning: poll wmic until exe is gone (spaced names OK); replace fixed sleeps after taskkill with this wait; 50ms backoff only while process still listed; cap after ~300 polls.
- Use taskkill /F /T in extra passes; remove blind retry Sleep in extract loop.
- Drop Sleep before launch in .onInstSuccess.

Upstream extractAppPackage.nsh should be diffed when upgrading electron-builder.

Made-with: Cursor